### PR TITLE
Downgrade ODP.Net because of a bug when querying materialized views

### DIFF
--- a/src/Backend.Fx.Persistence.Oracle/Backend.Fx.Persistence.Oracle.csproj
+++ b/src/Backend.Fx.Persistence.Oracle/Backend.Fx.Persistence.Oracle.csproj
@@ -22,7 +22,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.6.1" />
+        <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.5.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Error happens on different columns but consistently. Not happening in `Oracle.ManagedDataAccess.Core 23.5.1`

```
System.Data.DataException: Error parsing column 5 (OFFER_LEAD_TIME_RAW_VALUE=1 - Int64)

System.Data.DataException
Error parsing column 5 (OFFER_LEAD_TIME_RAW_VALUE=1 - Int64)
   at Dapper.SqlMapper.ThrowDataException(Exception ex, Int32 index, IDataReader reader, Object value) in /_/Dapper/SqlMapper.cs:line 3928
   at Deserialize63551f68-2134-4050-b46a-718890025aec(DbDataReader)
   at Dapper.SqlMapper.QueryAsync[T](IDbConnection cnn, Type effectiveType, CommandDefinition command)
   at Wombat.Adapters.Oracle.Shared.Offers.OfferRepository.SearchOffersByProductIdAsync(SearchConsumablesByProductIdParams searchParams, LoadOptions loadOptions, CancellationToken cancellationToken)
   at Wombat.Adapters.Oracle.Tests.Search.Consumables.TheConsumablesSearchView.<CanSearchProductsUsingSearchString>b__21_1(SearchProduct p)
   at Wombat.Adapters.Oracle.Tests.Search.Consumables.TheConsumablesSearchView.CanSearchProductsUsingSearchString()
   at Xunit.Sdk.TestInvoker`1.<>c__DisplayClass47_0.<<InvokeTestMethodAsync>b__1>d.MoveNext()
--- End of stack trace from previous location ---
   at Xunit.Sdk.ExecutionTimer.AggregateAsync(Func`1 asyncAction)
   at Xunit.Sdk.ExceptionAggregator.RunAsync(Func`1 code)

System.NullReferenceException
Object reference not set to an instance of an object.
   at OracleInternal.ServiceObjects.OracleFailoverMgrImpl.OnError(OracleConnection connection, CallHistoryRecord chr, Object mi, Exception ex, Boolean bTopLevelCall, Boolean& bCanRecordNewCall)
   at Oracle.ManagedDataAccess.Client.OracleDataReader.GetValue(Int32 i)
   at Deserialize63551f68-2134-4050-b46a-718890025aec(DbDataReader)
```